### PR TITLE
build(nix): add graph-tool

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@
 , sknw
 , nbval
 , pymks
+, graph-tool
 }:
 
 buildPythonPackage rec {
@@ -23,6 +24,7 @@ buildPythonPackage rec {
     sknw
     nbval
     pymks
+    graph-tool
   ];
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
graph-tool (wrapper for boost) will eventually replace networkx as
it's faster.